### PR TITLE
Bring in the modules for github_repo and github_team

### DIFF
--- a/modules/github_repo/main.tf
+++ b/modules/github_repo/main.tf
@@ -1,0 +1,46 @@
+resource "github_repository" "repository" {
+  name = "${var.repository_name}"
+
+  # Our repos should always be public. If you need to make something secret you better have a good reason
+  private = false
+
+  # We auto init so that github_branch_protection works
+  auto_init = true
+}
+
+resource "github_branch_protection" "branch" {
+  # As part of our SDLC we require that master branch can not be merged to unless...
+
+  repository = "${var.repository_name}"
+  branch     = "master"
+
+  # enforce protection on admins
+  enforce_admins = true
+
+  # all status checks pass
+  required_status_checks {
+    strict         = true
+    contexts       = []
+  }
+
+  # Tune review requirements
+  required_pull_request_reviews {
+    dismiss_stale_reviews = true
+  }
+
+  depends_on = ["github_repository.repository"]
+}
+
+resource "github_team_repository" "admin_teams" {
+  count      = "${var.admin_teams_count}"
+  team_id    = "${element(var.admin_teams, count.index)}"
+  repository = "${github_repository.repository.id}"
+  permission = "admin"
+}
+
+resource "github_team_repository" "pull_teams" {
+  count      = "${var.pull_teams_count}"
+  team_id    = "${element(var.pull_teams, count.index)}"
+  repository = "${github_repository.repository.id}"
+  permission = "pull"
+}

--- a/modules/github_repo/vars.tf
+++ b/modules/github_repo/vars.tf
@@ -1,0 +1,25 @@
+variable "repository_name" {
+  description = "The name of the repository that is to be created."
+}
+
+variable "admin_teams_count" {
+  description = "Required count variable representing number of teams passed to the admin_teams variable"
+  default     = 0
+}
+
+variable "admin_teams" {
+  description = "Admin team members"
+  type        = "list"
+  default     = []
+}
+
+variable "pull_teams_count" {
+  description = "Required count variable representing number of teams passed to the pull_teams variable"
+  default     = 0
+}
+
+variable "pull_teams" {
+  description = "Pull team members"
+  type        = "list"
+  default     = []
+}

--- a/modules/github_team/main.tf
+++ b/modules/github_team/main.tf
@@ -1,0 +1,18 @@
+resource "github_team" "team_name" {
+  name        = "${var.team_name}"
+  description = "${var.team_description}"
+  privacy     = "${var.privacy}"
+}
+
+resource "github_team_membership" "member" {
+  count    = "${length(var.members)}"
+  team_id  = "${github_team.team_name.id}"
+  username = "${element(var.members, count.index)}"
+  role     = "${replace(var.role, "/admin/", "maintainer")}"
+}
+
+resource "github_membership" "member" {
+  count    = "${length(var.members)}"
+  username = "${element(var.members, count.index)}"
+  role     = "${replace(var.role, "/maintainer/", "member")}"
+}

--- a/modules/github_team/outputs.tf
+++ b/modules/github_team/outputs.tf
@@ -1,0 +1,3 @@
+output "team_id" {
+  value = "${github_team.team_name.id}"
+}

--- a/modules/github_team/vars.tf
+++ b/modules/github_team/vars.tf
@@ -1,0 +1,22 @@
+variable "team_name" {
+  description = "Name of the team."
+}
+
+variable "team_description" {
+  description = "Team description."
+}
+
+variable "privacy" {
+  description = "Privacy level of the team."
+  default     = "closed"
+}
+
+variable "members" {
+  description = "List of members of the team."
+  type        = "list"
+}
+
+variable "role" {
+  description = "Role time of the members"
+  default     = "member"
+}


### PR DESCRIPTION
`github_repo` provides an opinionated repo defintion with branch protection, an admin team, and a push team. pull is not included because part of the opinionation is that the repos are always public.

`github_team` provides a simple implementation that combines _github_membership_, _github_team_, and _github_team_membership_ 